### PR TITLE
Suggestions

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -17,7 +17,7 @@ init(dirname(__DIR__) . '/views');
 
 get('/', function () {
     $length = getKeyLength();
-    list($err, $key) = generateKey($length, getMaxKeyLength());
+    list($err, $key) = generateKey($length, getKeyMaxLength());
 
     if ($err !== null) {
         stop($err);
@@ -32,7 +32,7 @@ get('/', function () {
 get('/text', function () {
     list($err, $key) = generateKey(
         getKeyLength(),
-        getMaxKeyLength()
+        getKeyMaxLength()
     );
 
     if ($err !== null) {
@@ -46,7 +46,7 @@ function getKeyLength(): int{
     return array_get_int($_GET, 'length', env_int('KEY_DEFAULT_LENGTH', 64));
 }
 
-function getMaxKeyLength(): int {
+function getKeyMaxLength(): int {
     return env_int('KEY_MAX_LENGTH', 1024);
 }
 

--- a/public/index.php
+++ b/public/index.php
@@ -1,10 +1,10 @@
 <?php
 
 use Kuria\Error\ErrorHandler;
-use function Siler\Env\env_var;
+use function Siler\array_get_int;
+use function Siler\Env\{env_int, env_var};
 use function Siler\Route\get;
-use function Siler\Twig\init;
-use function Siler\Twig\render;
+use function Siler\Twig\{init, render};
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
@@ -17,14 +17,44 @@ init(dirname(__DIR__) . '/views');
 
 get('/', function () {
     $length = getKeyLength();
+    list($err, $key) = generateKey($length, getMaxKeyLength());
+
+    if ($err !== null) {
+        stop($err);
+    }
+
     echo render('index.twig', [
-        'key' => generateKey($length),
+        'key' => $key,
          'length'  => $length
     ]);
 });
 
 get('/text', function () {
-    echo  generateKey(
-        getKeyLength()
+    list($err, $key) = generateKey(
+        getKeyLength(),
+        getMaxKeyLength()
     );
+
+    if ($err !== null) {
+        stop($err);
+    }
+
+    echo $key;
 });
+
+function getKeyLength(): int{
+    return array_get_int($_GET, 'length', env_int('KEY_DEFAULT_LENGTH', 64));
+}
+
+function getMaxKeyLength(): int {
+    return env_int('KEY_MAX_LENGTH', 1024);
+}
+
+function stop(string $error, ...$context): void {
+    echo sprintf($error, $context);
+
+    if (function_exists('fastcgi_finish_request')) {
+        fastcgi_finish_request();
+    }
+    exit();
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,14 +1,14 @@
 <?php
 
 use Kuria\Error\ErrorHandler;
-use function Siler\Dotenv\env;
+use function Siler\Env\env_var;
 use function Siler\Route\get;
 use function Siler\Twig\init;
 use function Siler\Twig\render;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$env = $_ENV['APP_ENV'] ?? 'production';
+$env = env_var('APP_ENV', 'production');
 $handler = (new ErrorHandler());
 $handler->setDebug($env === 'development');
 $handler->register();

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,6 +1,7 @@
 <?php
 
-use function Siler\Dotenv\env;
+use function Siler\array_get_int;
+use function Siler\Env\env_int;
 
 function stop(string $error, ...$context): void {
     echo sprintf($error, $context);
@@ -12,7 +13,7 @@ function stop(string $error, ...$context): void {
 }
 
 function generateKey(int $length) {
-    $max = env('KEY_MAX_LENGTH', 1024);
+    $max = env_int('KEY_MAX_LENGTH', 1024);
 
     if ($length <= 0) {
         stop('Length should be greater than 0');
@@ -28,5 +29,5 @@ function generateKey(int $length) {
 }
 
 function getKeyLength(): int{
-    return (int)($_GET['length'] ?? env('KEY_DEFAULT_LENGTH', 64));
+    return array_get_int($_GET, 'length', env_int('KEY_DEFAULT_LENGTH', 64));
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,33 +1,15 @@
 <?php
 
-use function Siler\array_get_int;
-use function Siler\Env\env_int;
-
-function stop(string $error, ...$context): void {
-    echo sprintf($error, $context);
-
-    if (function_exists('fastcgi_finish_request')) {
-        fastcgi_finish_request();
-    }
-    exit();
-}
-
-function generateKey(int $length) {
-    $max = env_int('KEY_MAX_LENGTH', 1024);
-
+function generateKey(int $length, int $max = 1024): array {
     if ($length <= 0) {
-        stop('Length should be greater than 0');
+        return ['Length should be greater than 0', null];
     }
 
     if ($length > $max) {
-        stop('Length should not be greater than %s', $max);
+        return ["Length should not be greater than $max", null];
     }
 
-    return substr(base64_encode(
+    return [null, substr(base64_encode(
         random_bytes($length)
-    ), 0,  $length);
-}
-
-function getKeyLength(): int{
-    return array_get_int($_GET, 'length', env_int('KEY_DEFAULT_LENGTH', 64));
+    ), 0,  $length)];
 }

--- a/views/index.twig
+++ b/views/index.twig
@@ -23,7 +23,7 @@
         <section class="container secret">
             <strong>{{ key }}</strong>
         </section>
-        <small><code>?length={{ length }}</small>
+        <small><code>?length={{ length }}</code></small>
     </div>
 </main>
 

--- a/views/index.twig
+++ b/views/index.twig
@@ -19,7 +19,7 @@
 <main>
     <div class="container">
         <h1>Random bytes generator</h1>
-        <p>Sometimes, I struggle generating a new secret key for an app, i need to open an interactive PHP terminal, writing a bit code. Every. Single. Time. This is the solution.</p>
+        <p>Sometimes, I struggle generating a new secret key for an app, I need to open an interactive PHP terminal, writing a bit code. Every. Single. Time. This is the solution.</p>
         <section class="container secret">
             <strong>{{ key }}</strong>
         </section>


### PR DESCRIPTION
Separating concerns, like splitting business rules and side-effects, would enable better test-ability as well.
Also, you should avoid modifying script execution behavior, like with `exit`, inside functions concerned about doing business rules, like `generateKey`.

The `[$err, $result]` tuple mimic could be better addressed with Siler's Result module, but I'm about to change it to something closer to Rust's Result, so I don't recommend using it right now :) 